### PR TITLE
Implement equality for ASN1OctetStringValue

### DIFF
--- a/ASN1-Model.package/ASN1OctetStringValue.class/instance/^equals.st
+++ b/ASN1-Model.package/ASN1OctetStringValue.class/instance/^equals.st
@@ -1,0 +1,9 @@
+comparing
+= anObject
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject
+		ifTrue: [ ^ true ].
+	self class = anObject class
+		ifFalse: [ ^ false ].
+	^ contents = anObject stringValue

--- a/ASN1-Model.package/ASN1OctetStringValue.class/instance/hash.st
+++ b/ASN1-Model.package/ASN1OctetStringValue.class/instance/hash.st
@@ -1,0 +1,5 @@
+comparing
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^ contents hash


### PR DESCRIPTION
 Solely use the contents for comparison. In the current usecase (teleservice handling) the module and type are the same anyway. We might want to change this in the future.

(from smalltalkhub)